### PR TITLE
Add initial Terraform GCP Memorystore modules for Redis and Memcached

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Terraform
+.terraform/
+.terraform.lock.hcl
+terraform.tfstate
+terraform.tfstate.*
+crash.log
+override.tf
+override.tf.json
+*.tfvars
+*.tfvars.json
+
+# IDE
+.vscode/
+.idea/
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2025 Marcos Paulo Pazzinatto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights  
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell      
+copies of the Software, and to permit persons to whom the Software is         
+furnished to do so, subject to the following conditions:                       
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.                                
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR     
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,       
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE    
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER         
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,  
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE  
+SOFTWARE.
+

--- a/examples/memcached-basic/main.tf
+++ b/examples/memcached-basic/main.tf
@@ -1,0 +1,33 @@
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "google" {
+  project = "my-project-id"
+  region  = "us-central1"
+}
+
+module "memorystore_memcached" {
+  source             = "../../modules/memcached"
+  name               = "app-memcached"
+  region             = "us-central1"
+  authorized_network = "projects/my-project-id/global/networks/default"
+
+  node_count     = 2
+  node_cpu       = 2
+  node_memory_mb = 4096
+
+  labels = {
+    env = "staging"
+    app = "rd-conversas"
+  }
+}
+
+output "endpoint" { value = module.memorystore_memcached.endpoint }
+

--- a/examples/redis-standard-ha/main.tf
+++ b/examples/redis-standard-ha/main.tf
@@ -1,0 +1,32 @@
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "google" {
+  project = "my-project-id"
+  region  = "us-central1"
+}
+
+module "memorystore_redis" {
+  source             = "../../modules/redis"
+  name               = "app-cache"
+  region             = "us-central1"
+  tier               = "STANDARD_HA"
+  memory_size_gb     = 4
+  authorized_network = "projects/my-project-id/global/networks/default"
+  redis_version      = "REDIS_6_X"
+  labels = {
+    env = "staging"
+    app = "rd-conversas"
+  }
+}
+
+output "host" { value = module.memorystore_redis.host }
+output "port" { value = module.memorystore_redis.port }
+

--- a/memcached.tf
+++ b/memcached.tf
@@ -1,0 +1,31 @@
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "google" {
+  project = "my-project-id"
+  region  = "us-central1"
+}
+
+module "memorystore_memcached" {
+  source             = "../../modules/memcached"
+  name               = "app-memcached"
+  region             = "us-central1"
+  authorized_network = "projects/my-project-id/global/networks/default"
+
+  node_count = 2
+  node_cpu   = 2            # per-node vCPU
+  node_memory_mb = 4096     # per-node memory
+  labels = {
+    env = "staging"
+  }
+}
+
+output "memcached_endpoint" { value = module.memorystore_memcached.endpoint }
+

--- a/modules/memcached/main.tf
+++ b/modules/memcached/main.tf
@@ -1,0 +1,30 @@
+resource "google_memcache_instance" "this" {
+  name               = var.name
+  region             = var.region
+  authorized_network = var.authorized_network
+  display_name       = var.display_name
+
+  node_count = var.node_count
+
+  node_config {
+    cpu_count      = var.node_cpu
+    memory_size_mb = var.node_memory_mb
+  }
+
+  parameters {
+    params = var.parameters
+  }
+
+  labels = var.labels
+
+  maintenance_policy {
+    weekly_maintenance_window {
+      day = var.maintenance_day
+      start_time {
+        hours   = var.maintenance_start_hour
+        minutes = var.maintenance_start_minute
+      }
+    }
+  }
+}
+

--- a/modules/memcached/outputs.tf
+++ b/modules/memcached/outputs.tf
@@ -1,0 +1,15 @@
+output "id" {
+  description = "ID of the Memcached instance."
+  value       = google_memcache_instance.this.id
+}
+
+output "endpoint" {
+  description = "Memcached endpoint (IP and port)."
+  value       = google_memcache_instance.this.discovery_endpoint
+}
+
+output "node_count" {
+  description = "Number of nodes."
+  value       = google_memcache_instance.this.node_count
+}
+

--- a/modules/memcached/variables.tf
+++ b/modules/memcached/variables.tf
@@ -1,0 +1,69 @@
+variable "name" {
+  type        = string
+  description = "Name of the Memcached instance."
+}
+
+variable "region" {
+  type        = string
+  description = "GCP region for the instance."
+}
+
+variable "authorized_network" {
+  type        = string
+  description = "Full resource path of the authorized VPC network."
+}
+
+variable "display_name" {
+  type        = string
+  description = "Optional display name."
+  default     = null
+}
+
+variable "node_count" {
+  type        = number
+  description = "Number of Memcached nodes."
+  default     = 1
+}
+
+variable "node_cpu" {
+  type        = number
+  description = "vCPU per node."
+  default     = 2
+}
+
+variable "node_memory_mb" {
+  type        = number
+  description = "Memory per node in MB."
+  default     = 4096
+}
+
+variable "parameters" {
+  type        = map(string)
+  description = "Memcached parameters map."
+  default     = {}
+}
+
+variable "labels" {
+  type        = map(string)
+  description = "Resource labels."
+  default     = {}
+}
+
+variable "maintenance_day" {
+  type        = string
+  description = "Maintenance day (e.g., MONDAY)."
+  default     = "MONDAY"
+}
+
+variable "maintenance_start_hour" {
+  type        = number
+  description = "Maintenance start hour (0–23)."
+  default     = 3
+}
+
+variable "maintenance_start_minute" {
+  type        = number
+  description = "Maintenance start minute (0–59)."
+  default     = 0
+}
+

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -1,0 +1,27 @@
+resource "google_redis_instance" "this" {
+  name               = var.name
+  tier               = var.tier
+  memory_size_gb     = var.memory_size_gb
+  region             = var.region
+  authorized_network = var.authorized_network
+  redis_version      = var.redis_version
+
+  display_name = var.display_name
+  reserved_ip_range = var.reserved_ip_range
+
+  labels = var.labels
+
+  maintenance_policy {
+    weekly_maintenance_window {
+      day = var.maintenance_day
+      start_time {
+        hours   = var.maintenance_start_hour
+        minutes = var.maintenance_start_minute
+      }
+    }
+  }
+
+  # Optional flags (kept minimal to avoid provider/API drift)
+  # auth_enabled = var.auth_enabled
+}
+

--- a/modules/redis/outputs.tf
+++ b/modules/redis/outputs.tf
@@ -1,0 +1,20 @@
+output "id" {
+  description = "ID of the Redis instance."
+  value       = google_redis_instance.this.id
+}
+
+output "host" {
+  description = "Host of the Redis instance."
+  value       = google_redis_instance.this.host
+}
+
+output "port" {
+  description = "Port of the Redis instance."
+  value       = google_redis_instance.this.port
+}
+
+output "current_location_id" {
+  description = "Zone/Location where the instance is currently provisioned."
+  value       = google_redis_instance.this.current_location_id
+}
+

--- a/modules/redis/variables.tf
+++ b/modules/redis/variables.tf
@@ -1,0 +1,74 @@
+variable "name" {
+  type        = string
+  description = "Name of the Redis instance."
+}
+
+variable "region" {
+  type        = string
+  description = "GCP region for the instance."
+}
+
+variable "tier" {
+  type        = string
+  description = "Service tier: BASIC or STANDARD_HA."
+  default     = "BASIC"
+}
+
+variable "memory_size_gb" {
+  type        = number
+  description = "Memory size in GB."
+}
+
+variable "authorized_network" {
+  type        = string
+  description = "Full resource path of the authorized VPC network."
+}
+
+variable "redis_version" {
+  type        = string
+  description = "Redis version (e.g., REDIS_6_X, REDIS_7_0)."
+  default     = "REDIS_6_X"
+}
+
+variable "display_name" {
+  type        = string
+  description = "Optional display name."
+  default     = null
+}
+
+variable "reserved_ip_range" {
+  type        = string
+  description = "CIDR range for the instance if you want to reserve IPs in a specific range."
+  default     = null
+}
+
+variable "labels" {
+  type        = map(string)
+  description = "Resource labels."
+  default     = {}
+}
+
+variable "maintenance_day" {
+  type        = string
+  description = "Maintenance day (e.g., MONDAY)."
+  default     = "MONDAY"
+}
+
+variable "maintenance_start_hour" {
+  type        = number
+  description = "Maintenance start hour (0–23)."
+  default     = 3
+}
+
+variable "maintenance_start_minute" {
+  type        = number
+  description = "Maintenance start minute (0–59)."
+  default     = 0
+}
+
+# variable "auth_enabled" {
+#   type        = bool
+#   description = "Enable Redis AUTH. Token is not retrievable via Terraform."
+#   default     = false
+# }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0"
+    }
+  }
+}
+


### PR DESCRIPTION
This pull request adds the initial implementation of Terraform modules to provision and manage Google Cloud Memorystore instances for both Redis and Memcached.

Changes include:
- `modules/redis`: Configurable Redis instance with tier, size, network, version, and labels.
- `modules/memcached`: Configurable Memcached instance with node count, CPU, memory, parameters, and labels.
- Example usage for Redis (STANDARD_HA) and Memcached (BASIC) deployments.
- `README.md` with usage instructions and requirements.
- `.gitignore` and `LICENSE` files.
- Root `versions.tf` for provider configuration.
